### PR TITLE
ci: use .node-version to setup

### DIFF
--- a/.github/workflows/before-merge.yml
+++ b/.github/workflows/before-merge.yml
@@ -10,16 +10,18 @@ jobs:
     name: Lint, Unit Test and Build
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 14.16.0 ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Read .node-version
+        id: node-version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.node-version
+      - name: Use Node.js ${{ steps.node-version.outputs.content }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.node-version.outputs.content }}
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
@@ -49,15 +51,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 14.16.0 ]
         browser: [ chrome, firefox, edge ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Read .node-version
+        id: node-version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.node-version
+      - name: Use Node.js ${{ steps.node-version.outputs.content }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.node-version.outputs.content }}
       - name: Download Artifact
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,18 @@ jobs:
     name: Lint, Unit Test and Build
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 14.16.0 ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Read .node-version
+        id: node-version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.node-version
+      - name: Use Node.js ${{ steps.node-version.outputs.content }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.node-version.outputs.content }}
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
@@ -49,15 +51,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 14.16.0 ]
         browser: [ chrome, firefox, edge ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Read .node-version
+        id: node-version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./.node-version
+      - name: Use Node.js ${{ steps.node-version.outputs.content }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.node-version.outputs.content }}
       - name: Download Artifact
         uses: actions/download-artifact@master
         with:


### PR DESCRIPTION
## What
Make it import `.node-version` and use the version on CI.

## Why
Renovate doesn't update the Node.js version in the files for GitHub Actions.

https://github.com/tanakaworld/tanaka.world/pull/90